### PR TITLE
Added UpdateChildren attribute to content type

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -4245,6 +4245,15 @@
       </xsd:annotation>
     </xsd:attribute>
 
+    <xsd:attribute name="UpdateChildren" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:appinfo>Added with schema version 20xxxx</xsd:appinfo>
+        <xsd:documentation xml:lang="en">
+          Declares whether changes to the content type document set settings will be udpated on inherited content types, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
   </xsd:complexType>
 
   <xsd:complexType name="FeaturesList">

--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -4057,6 +4057,15 @@
       </xsd:annotation>
     </xsd:attribute>
 
+    <xsd:attribute name="UpdateChildren" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:appinfo>Added with schema version 20xxxx</xsd:appinfo>
+        <xsd:documentation xml:lang="en">
+          Declares whether changes to the content type will be udpated on inherited content types, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
     <xsd:anyAttribute processContents="skip"/>
 
   </xsd:complexType>


### PR DESCRIPTION
There should be an UpdateChildren attribute on the content type definition so that changes made to the content type can be pushed down to the children.

The idea is that if this attribute is set to true changes to attributes that supports push down will be pushed down to children. If FieldRefs do not specify the UpdateChildren attribute the content type level attribute should be used for the FieldRef. If a FeildRef UpdateChildren attribute is specified that attribute takes precedence. If none of the attributes are specified it should default to false.

This provisioning engine logic will be difficult/impossible to implement without also including the changes that I contributed in PnP Sites-Core [#2500](https://github.com/SharePoint/PnP-Sites-Core/pull/2500) as the current implementation of the engine does not preserve undefined attributes.

The lack of #2500 removes the possibility for FieldRefs to fall back on the content type level attribute.

Also added UpdateChildren to the DocumentSetTemplate node.