### PR TITLE
Added TeamVisibility HiddenMembership

### DIFF
--- a/PnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/PnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -8776,6 +8776,14 @@
               </xsd:documentation>
             </xsd:annotation>
           </xsd:enumeration>
+          <xsd:enumeration value="HiddenMembership">
+            <xsd:annotation>
+              <xsd:appinfo></xsd:appinfo>
+              <xsd:documentation xml:lang="en">
+                Defines a M365 Education Tenant Class Team which is only prepared without the students having access.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
         </xsd:restriction>
       </xsd:simpleType>
 


### PR DESCRIPTION
M365 Education Tenants have an additional Team visibility option called HiddenMembership. This is used to prepare a Team for a class without the students having access. As soon the teacher is ready, the Team is activated and the students gain access.

The added Team Visibility Option HiddenMembership enables the possibility to create a ProvisioningTemplate of a Class Team.

The Option is needed to add this Option to the Provisioning/Model/Teams/BaseTeam/TeamVisiblity enum.